### PR TITLE
Feat - feat: 주문 기반 카카오페이 결제 연동 추가

### DIFF
--- a/src/main/java/Comprehensive_Design_Project/CUK_Compasser/domain/order/controller/OrderController.java
+++ b/src/main/java/Comprehensive_Design_Project/CUK_Compasser/domain/order/controller/OrderController.java
@@ -20,66 +20,43 @@ public class OrderController {
 
     /**
      * 사용자 주문 생성 API
-     * - 사용자가 랜덤박스와 수량을 선택해 주문을 생성한다.
-     * - 내부적으로 Reservation을 생성하여 사용자 주문 화면에서 사용한다.
      */
     @PostMapping
     public ApiResponse<OrderRespDTO.CreateOrderResultDTO> createOrder(
             @AuthenticationPrincipal CustomUserDetails userDetails,
             @RequestBody @Valid OrderReqDTO.CreateOrderDTO request
     ) {
-        OrderRespDTO.CreateOrderResultDTO response =
-                orderService.createOrder(userDetails.getMember().getId(), request);
-
-        return ApiResponse.onSuccess(SuccessStatus.ORDER_CREATED, response);
-    }
-
-    /**
-     * 사용자 송금 완료 처리 API
-     * - 사용자가 '송금 완료' 버튼을 눌렀을 때 호출된다.
-     * - 주문의 결제 상태를 PENDING -> PAID 로 변경한다.
-     */
-    @PatchMapping("/{orderId}/complete")
-    public ApiResponse<OrderRespDTO.CompleteOrderResultDTO> completeOrder(
-            @AuthenticationPrincipal CustomUserDetails userDetails,
-            @PathVariable Long orderId
-    ) {
-        OrderRespDTO.CompleteOrderResultDTO response =
-                orderService.completeOrder(userDetails.getMember().getId(), orderId);
-
-        return ApiResponse.onSuccess(SuccessStatus.ORDER_COMPLETED, response);
+        return ApiResponse.onSuccess(
+                SuccessStatus.ORDER_CREATED,
+                orderService.createOrder(userDetails.getMember().getId(), request)
+        );
     }
 
     /**
      * 사용자 주문 취소 API
-     * - 사용자가 자신의 주문을 취소할 때 호출된다.
-     * - 내부적으로 Reservation 상태를 REQUESTED -> CANCELED 로 변경한다.
-     * - 아직 점주가 처리하지 않은 주문만 취소 가능하도록 제한할 수 있다.
      */
     @PatchMapping("/{orderId}/cancel")
     public ApiResponse<OrderRespDTO.CancelOrderResultDTO> cancelOrder(
             @AuthenticationPrincipal CustomUserDetails userDetails,
             @PathVariable Long orderId
     ) {
-        OrderRespDTO.CancelOrderResultDTO response =
-                orderService.cancelOrder(userDetails.getMember().getId(), orderId);
-
-        return ApiResponse.onSuccess(SuccessStatus.ORDER_CANCELED, response);
+        return ApiResponse.onSuccess(
+                SuccessStatus.ORDER_CANCELED,
+                orderService.cancelOrder(userDetails.getMember().getId(), orderId)
+        );
     }
 
     /**
      * 사용자 주문 상태 조회 API
-     * - 사용자가 자신의 주문 상세 상태를 조회한다.
-     * - 외부 API에서는 orderId 개념으로 사용하지만 내부적으로는 Reservation 데이터를 조회한다.
      */
     @GetMapping("/{orderId}/status")
     public ApiResponse<OrderRespDTO.OrderStatusDTO> getOrderStatus(
             @AuthenticationPrincipal CustomUserDetails userDetails,
             @PathVariable Long orderId
     ) {
-        OrderRespDTO.OrderStatusDTO response =
-                orderService.getOrderStatus(userDetails.getMember().getId(), orderId);
-
-        return ApiResponse.onSuccess(SuccessStatus.ORDER_STATUS_FOUND, response);
+        return ApiResponse.onSuccess(
+                SuccessStatus.ORDER_STATUS_FOUND,
+                orderService.getOrderStatus(userDetails.getMember().getId(), orderId)
+        );
     }
 }

--- a/src/main/java/Comprehensive_Design_Project/CUK_Compasser/domain/order/service/OrderService.java
+++ b/src/main/java/Comprehensive_Design_Project/CUK_Compasser/domain/order/service/OrderService.java
@@ -7,9 +7,7 @@ public interface OrderService {
 
     OrderRespDTO.CreateOrderResultDTO createOrder(Long memberId, OrderReqDTO.CreateOrderDTO request);
 
-    OrderRespDTO.CompleteOrderResultDTO completeOrder(Long memberId, Long orderId);
+    OrderRespDTO.CancelOrderResultDTO cancelOrder(Long memberId, Long orderId);
 
     OrderRespDTO.OrderStatusDTO getOrderStatus(Long memberId, Long orderId);
-
-    OrderRespDTO.CancelOrderResultDTO cancelOrder(Long memberId, Long orderId);
 }

--- a/src/main/java/Comprehensive_Design_Project/CUK_Compasser/domain/order/service/OrderServiceImpl.java
+++ b/src/main/java/Comprehensive_Design_Project/CUK_Compasser/domain/order/service/OrderServiceImpl.java
@@ -32,6 +32,7 @@ public class OrderServiceImpl implements OrderService {
      * 사용자 주문 생성
      * - 사용자 주문 화면에서 사용할 Reservation 데이터를 생성한다.
      * - 주문 생성 시 예약/결제/픽업 상태의 기본값을 함께 세팅한다.
+     * - 결제는 이후 카카오페이 ready/approve API에서 진행한다.
      */
     @Override
     @Transactional
@@ -52,9 +53,9 @@ public class OrderServiceImpl implements OrderService {
                 .randomBox(randomBox)
                 .requestedQuantity(request.getQuantity())
                 .totalPrice(totalPrice)
-                .status(ReservationStatus.REQUESTED)      // 주문 요청 상태
-                .paymentStatus(PaymentStatus.PENDING)     // 아직 송금 전
-                .pickupStatus(PickupStatus.WAITING)       // 아직 준비 시작 전
+                .status(ReservationStatus.REQUESTED)
+                .paymentStatus(PaymentStatus.PENDING)
+                .pickupStatus(PickupStatus.WAITING)
                 .build();
 
         Reservation savedReservation = reservationRepository.save(reservation);
@@ -63,34 +64,9 @@ public class OrderServiceImpl implements OrderService {
     }
 
     /**
-     * 사용자 송금 완료 처리
-     * - 사용자가 '송금 완료' 버튼을 눌렀을 때 결제 상태를 PAID로 변경한다.
-     * - 이미 취소/거절된 주문은 처리할 수 없다.
-     * - 이미 결제 완료된 주문은 중복 처리할 수 없다.
-     */
-    @Override
-    @Transactional
-    public OrderRespDTO.CompleteOrderResultDTO completeOrder(Long memberId, Long orderId) {
-        Member member = memberRepository.findById(memberId)
-                .orElseThrow(() -> new GeneralException(ErrorStatus.USER_NOT_FOUND));
-
-        Reservation reservation = reservationRepository.findByIdAndMember(orderId, member)
-                .orElseThrow(() -> new GeneralException(ErrorStatus.RESERVATION_NOT_FOUND));
-
-        validateCompleteOrder(reservation);
-
-        reservation.setPaymentStatus(PaymentStatus.PAID);
-
-        return OrderConverter.toCompleteOrderResultDTO(
-                reservation,
-                "송금 완료 처리되었습니다. 사장님의 확인 후 주문이 진행됩니다."
-        );
-    }
-
-    /**
      * 사용자 주문 취소
-     * - 사용자는 아직 점주가 처리하지 않은 REQUESTED 상태의 주문만 취소할 수 있다.
-     * - 취소 시 Reservation 상태를 CANCELED로 변경한다.
+     * - 아직 점주가 처리하지 않은 REQUESTED 상태의 주문만 취소할 수 있다.
+     * - 이미 결제 완료된 주문은 취소할 수 없다.
      */
     @Override
     @Transactional
@@ -104,6 +80,7 @@ public class OrderServiceImpl implements OrderService {
         validateCancelOrder(reservation);
 
         reservation.setStatus(ReservationStatus.CANCELED);
+        reservation.setPaymentStatus(PaymentStatus.CANCELED);
 
         return OrderConverter.toCancelOrderResultDTO(
                 reservation,
@@ -128,10 +105,6 @@ public class OrderServiceImpl implements OrderService {
 
     /**
      * 주문 생성 가능 여부 검증
-     * - 수량이 1 이상인지 확인
-     * - 랜덤박스가 판매 가능한 상태인지 확인
-     * - 재고가 충분한지 확인
-     * - 구매 제한 수량을 초과하지 않는지 확인
      */
     private void validateCreateOrder(RandomBox randomBox, Integer quantity) {
         if (quantity == null || quantity < 1) {
@@ -152,24 +125,9 @@ public class OrderServiceImpl implements OrderService {
     }
 
     /**
-     * 송금 완료 처리 가능 여부 검증
-     * - 거절되거나 취소된 주문은 결제 완료 처리할 수 없다.
-     * - 이미 결제 완료된 주문은 중복 처리할 수 없다.
-     */
-    private void validateCompleteOrder(Reservation reservation) {
-        if (reservation.getStatus() == ReservationStatus.REJECTED ||
-                reservation.getStatus() == ReservationStatus.CANCELED) {
-            throw new GeneralException(ErrorStatus.RESERVATION_ALREADY_PROCESSED);
-        }
-
-        if (reservation.getPaymentStatus() == PaymentStatus.PAID) {
-            throw new GeneralException(ErrorStatus.ORDER_ALREADY_PAID);
-        }
-    }
-
-    /**
      * 주문 취소 가능 여부 검증
      * - 아직 점주가 처리하지 않은 REQUESTED 상태만 취소 가능하다.
+     * - 결제 완료된 예약은 취소 불가
      */
     private void validateCancelOrder(Reservation reservation) {
         if (reservation.getStatus() != ReservationStatus.REQUESTED) {

--- a/src/main/java/Comprehensive_Design_Project/CUK_Compasser/domain/reservation/controller/KakaoPayCallbackController.java
+++ b/src/main/java/Comprehensive_Design_Project/CUK_Compasser/domain/reservation/controller/KakaoPayCallbackController.java
@@ -1,0 +1,50 @@
+package Comprehensive_Design_Project.CUK_Compasser.domain.reservation.controller;
+
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.HttpHeaders;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.*;
+
+import java.net.URI;
+
+@RestController
+@RequiredArgsConstructor
+@RequestMapping("/payments/kakaopay")
+public class KakaoPayCallbackController {
+
+    @GetMapping("/success")
+    public ResponseEntity<Void> success(
+            @RequestParam Long reservationId,
+            @RequestParam("pg_token") String pgToken
+    ) {
+        URI redirectUri = URI.create(
+                "http://localhost:3000/payment/success?reservationId=" + reservationId + "&pg_token=" + pgToken
+        );
+
+        return ResponseEntity.status(302)
+                .header(HttpHeaders.LOCATION, redirectUri.toString())
+                .build();
+    }
+
+    @GetMapping("/cancel")
+    public ResponseEntity<Void> cancel(@RequestParam Long reservationId) {
+        URI redirectUri = URI.create(
+                "http://localhost:3000/payment/cancel?reservationId=" + reservationId
+        );
+
+        return ResponseEntity.status(302)
+                .header(HttpHeaders.LOCATION, redirectUri.toString())
+                .build();
+    }
+
+    @GetMapping("/fail")
+    public ResponseEntity<Void> fail(@RequestParam Long reservationId) {
+        URI redirectUri = URI.create(
+                "http://localhost:3000/payment/fail?reservationId=" + reservationId
+        );
+
+        return ResponseEntity.status(302)
+                .header(HttpHeaders.LOCATION, redirectUri.toString())
+                .build();
+    }
+}

--- a/src/main/java/Comprehensive_Design_Project/CUK_Compasser/domain/reservation/controller/ReservationPaymentController.java
+++ b/src/main/java/Comprehensive_Design_Project/CUK_Compasser/domain/reservation/controller/ReservationPaymentController.java
@@ -1,0 +1,76 @@
+package Comprehensive_Design_Project.CUK_Compasser.domain.reservation.controller;
+
+import Comprehensive_Design_Project.CUK_Compasser.domain.reservation.dto.KakaoPayRespDTO;
+import Comprehensive_Design_Project.CUK_Compasser.domain.reservation.service.ReservationService;
+import Comprehensive_Design_Project.CUK_Compasser.global.common.apiPayload.ApiResponse;
+import Comprehensive_Design_Project.CUK_Compasser.global.common.apiPayload.code.status.SuccessStatus;
+import Comprehensive_Design_Project.CUK_Compasser.global.security.userDetails.CustomUserDetails;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import lombok.RequiredArgsConstructor;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.web.bind.annotation.*;
+
+@RestController
+@RequiredArgsConstructor
+@RequestMapping("/reservations")
+@Tag(name = "Reservation Payment", description = "사용자 예약 결제 API")
+public class ReservationPaymentController {
+
+    private final ReservationService reservationService;
+
+    @Operation(
+            summary = "카카오페이 결제 준비",
+            description = "사용자 본인 예약 기준으로 카카오페이 결제창 진입을 위한 tid와 redirectUrl을 생성합니다."
+    )
+    @PostMapping("/{reservationId}/payment/ready")
+    public ApiResponse<KakaoPayRespDTO.ReadyResultDTO> readyKakaoPay(
+            @PathVariable Long reservationId,
+            @AuthenticationPrincipal CustomUserDetails userDetails
+    ) {
+        return ApiResponse.onSuccess(
+                SuccessStatus.RESERVATION_PAYMENT_READY,
+                reservationService.readyKakaoPay(reservationId, userDetails.getMember().getId())
+        );
+    }
+
+    @Operation(
+            summary = "카카오페이 결제 승인",
+            description = "카카오페이 결제 완료 후 전달받은 pg_token으로 최종 결제를 승인합니다."
+    )
+    @PostMapping("/{reservationId}/payment/approve")
+    public ApiResponse<KakaoPayRespDTO.ApproveResultDTO> approveKakaoPay(
+            @PathVariable Long reservationId,
+            @RequestParam("pg_token") String pgToken,
+            @AuthenticationPrincipal CustomUserDetails userDetails
+    ) {
+        return ApiResponse.onSuccess(
+                SuccessStatus.RESERVATION_PAYMENT_APPROVED,
+                reservationService.approveKakaoPay(reservationId, userDetails.getMember().getId(), pgToken)
+        );
+    }
+
+    /*
+    결제 취소 API
+        이건 주문은 살려두고 결제만 취소하는 것이야.
+        reservationStatus = REQUESTED 그대로
+        paymentStatus = CANCELED
+
+        예약은 아직 유효
+        다만 이번 결제 시도만 취소됨
+        사용자는 같은 reservationId로 다시 결제 가능
+    */
+    @Operation(
+            summary = "카카오페이 결제전 결제창에 취소 처리",
+            description = "결제창에서 사용자가 취소한 경우 결제 상태만 CANCELED로 변경합니다."
+    )
+    @PostMapping("/{reservationId}/payment/cancel")
+    public ApiResponse<Void> cancelKakaoPay(
+            @PathVariable Long reservationId,
+            @AuthenticationPrincipal CustomUserDetails userDetails
+    ) {
+        reservationService.cancelKakaoPay(reservationId, userDetails.getMember().getId());
+        return ApiResponse.onSuccess(SuccessStatus.OK, null);
+    }
+
+}

--- a/src/main/java/Comprehensive_Design_Project/CUK_Compasser/domain/reservation/dto/KakaoPayReqDTO.java
+++ b/src/main/java/Comprehensive_Design_Project/CUK_Compasser/domain/reservation/dto/KakaoPayReqDTO.java
@@ -1,0 +1,35 @@
+package Comprehensive_Design_Project.CUK_Compasser.domain.reservation.dto;
+
+import lombok.*;
+
+public class KakaoPayReqDTO {
+
+    @Getter
+    @Builder
+    @NoArgsConstructor
+    @AllArgsConstructor
+    public static class ReadyRequestDTO {
+        private String cid;
+        private String partner_order_id;
+        private String partner_user_id;
+        private String item_name;
+        private Integer quantity;
+        private Integer total_amount;
+        private Integer tax_free_amount;
+        private String approval_url;
+        private String cancel_url;
+        private String fail_url;
+    }
+
+    @Getter
+    @Builder
+    @NoArgsConstructor
+    @AllArgsConstructor
+    public static class ApproveRequestDTO {
+        private String cid;
+        private String tid;
+        private String partner_order_id;
+        private String partner_user_id;
+        private String pg_token;
+    }
+}

--- a/src/main/java/Comprehensive_Design_Project/CUK_Compasser/domain/reservation/dto/KakaoPayRespDTO.java
+++ b/src/main/java/Comprehensive_Design_Project/CUK_Compasser/domain/reservation/dto/KakaoPayRespDTO.java
@@ -1,0 +1,67 @@
+package Comprehensive_Design_Project.CUK_Compasser.domain.reservation.dto;
+
+import lombok.*;
+
+public class KakaoPayRespDTO {
+
+    @Getter
+    @NoArgsConstructor
+    @AllArgsConstructor
+    @Builder
+    public static class ReadyResponseDTO {
+        private String tid;
+        private String next_redirect_app_url;
+        private String next_redirect_mobile_url;
+        private String next_redirect_pc_url;
+        private String created_at;
+    }
+
+    @Getter
+    @NoArgsConstructor
+    @AllArgsConstructor
+    @Builder
+    public static class ApproveResponseDTO {
+        private String aid;
+        private String tid;
+        private String cid;
+        private String partner_order_id;
+        private String partner_user_id;
+        private String item_name;
+        private Integer quantity;
+        private Amount amount;
+        private String approved_at;
+
+        @Getter
+        @NoArgsConstructor
+        @AllArgsConstructor
+        @Builder
+        public static class Amount {
+            private Integer total;
+            private Integer tax_free;
+            private Integer vat;
+            private Integer discount;
+        }
+    }
+
+    @Getter
+    @Builder
+    @NoArgsConstructor
+    @AllArgsConstructor
+    public static class ReadyResultDTO {
+        private Long reservationId;
+        private String tid;
+        private String redirectUrl;
+        private String paymentStatus;
+    }
+
+    @Getter
+    @Builder
+    @NoArgsConstructor
+    @AllArgsConstructor
+    public static class ApproveResultDTO {
+        private Long reservationId;
+        private String paymentMethod;
+        private String paymentStatus;
+        private String approvedAt;
+    }
+}

--- a/src/main/java/Comprehensive_Design_Project/CUK_Compasser/domain/reservation/entity/PaymentStatus.java
+++ b/src/main/java/Comprehensive_Design_Project/CUK_Compasser/domain/reservation/entity/PaymentStatus.java
@@ -1,11 +1,9 @@
 package Comprehensive_Design_Project.CUK_Compasser.domain.reservation.entity;
 
 public enum PaymentStatus {
-    /**
-     * 사용자 결제(송금) 진행 상태
-     * 사용자 주문 API에서 사용
-     */
-    //돈 관련 상태
-    PENDING,
-    PAID
+    PENDING,   // 결제 전
+    READY,     // 카카오페이 ready 완료, 결제창 진입 가능
+    PAID,      // 승인 완료
+    FAILED,    // 결제 실패
+    CANCELED   // 결제 취소
 }

--- a/src/main/java/Comprehensive_Design_Project/CUK_Compasser/domain/reservation/entity/Reservation.java
+++ b/src/main/java/Comprehensive_Design_Project/CUK_Compasser/domain/reservation/entity/Reservation.java
@@ -1,6 +1,7 @@
 package Comprehensive_Design_Project.CUK_Compasser.domain.reservation.entity;
 
 import Comprehensive_Design_Project.CUK_Compasser.domain.member.entity.Member;
+import Comprehensive_Design_Project.CUK_Compasser.domain.order.entity.OrderStatus;
 import Comprehensive_Design_Project.CUK_Compasser.domain.randomBox.entity.RandomBox;
 import Comprehensive_Design_Project.CUK_Compasser.domain.store.entity.Store;
 import Comprehensive_Design_Project.CUK_Compasser.global.common.BaseEntity;
@@ -93,6 +94,25 @@ public class Reservation extends BaseEntity {
     // 거절 사유
     @Column(name = "reject_reason", length = 500)
     private String rejectReason;
+
+    @Column(name = "payment_tid", length = 100)
+    private String paymentTid;
+
+    @Column(name = "payment_method", length = 30)
+    private String paymentMethod;
+
+    @Column(name = "paid_at")
+    private LocalDateTime paidAt;
+
+    public void updatePaymentTid(String paymentTid) {
+        this.paymentTid = paymentTid;
+    }
+
+    public void markPaid(String paymentMethod) {
+        this.paymentMethod = paymentMethod;
+        this.paidAt = LocalDateTime.now();
+        this.status = OrderStatus.PAID;
+    }
 
     @PrePersist
     protected void prePersist() {

--- a/src/main/java/Comprehensive_Design_Project/CUK_Compasser/domain/reservation/entity/Reservation.java
+++ b/src/main/java/Comprehensive_Design_Project/CUK_Compasser/domain/reservation/entity/Reservation.java
@@ -1,7 +1,6 @@
 package Comprehensive_Design_Project.CUK_Compasser.domain.reservation.entity;
 
 import Comprehensive_Design_Project.CUK_Compasser.domain.member.entity.Member;
-import Comprehensive_Design_Project.CUK_Compasser.domain.order.entity.OrderStatus;
 import Comprehensive_Design_Project.CUK_Compasser.domain.randomBox.entity.RandomBox;
 import Comprehensive_Design_Project.CUK_Compasser.domain.store.entity.Store;
 import Comprehensive_Design_Project.CUK_Compasser.global.common.BaseEntity;
@@ -34,32 +33,23 @@ public class Reservation extends BaseEntity {
 
     // 예약한 사용자
     @ManyToOne(fetch = FetchType.LAZY, optional = false)
-    @JoinColumn(
-            name = "member_id",
-            nullable = false,
-            foreignKey = @ForeignKey(name = "fk_resv_member")
-    )
+    @JoinColumn(name = "member_id", nullable = false,
+            foreignKey = @ForeignKey(name = "fk_resv_member"))
     private Member member;
 
     // 예약이 속한 스토어
     @ManyToOne(fetch = FetchType.LAZY, optional = false)
-    @JoinColumn(
-            name = "store_id",
-            nullable = false,
-            foreignKey = @ForeignKey(name = "fk_resv_store")
-    )
+    @JoinColumn(name = "store_id", nullable = false,
+            foreignKey = @ForeignKey(name = "fk_resv_store"))
     private Store store;
 
     // 예약 대상 랜덤박스
     @ManyToOne(fetch = FetchType.LAZY, optional = false)
-    @JoinColumn(
-            name = "random_box_id",
-            nullable = false,
-            foreignKey = @ForeignKey(name = "fk_resv_random_box")
-    )
+    @JoinColumn(name = "random_box_id", nullable = false,
+            foreignKey = @ForeignKey(name = "fk_resv_random_box"))
     private RandomBox randomBox;
 
-    // 예약 상태
+    // 예약 상태: 요청/승인/거절/취소
     @Builder.Default
     @Enumerated(EnumType.STRING)
     @Column(name = "status", nullable = false, length = 30)
@@ -73,9 +63,7 @@ public class Reservation extends BaseEntity {
     @Column(name = "total_price", nullable = false)
     private Integer totalPrice;
 
-    @Column(name = "deposit_confirmed_at")
-    private LocalDateTime depositConfirmedAt;
-
+    // 픽업 완료 시각
     @Column(name = "picked_up_at")
     private LocalDateTime pickedUpAt;
 
@@ -91,28 +79,21 @@ public class Reservation extends BaseEntity {
     @Column(name = "pickup_status", nullable = false, length = 30)
     private PickupStatus pickupStatus = PickupStatus.WAITING;
 
-    // 거절 사유
+    // 거절/취소 사유
     @Column(name = "reject_reason", length = 500)
     private String rejectReason;
 
+    // 카카오페이 ready 응답의 tid
     @Column(name = "payment_tid", length = 100)
     private String paymentTid;
 
+    // 결제 수단
     @Column(name = "payment_method", length = 30)
     private String paymentMethod;
 
+    // 실제 결제 완료 시각
     @Column(name = "paid_at")
     private LocalDateTime paidAt;
-
-    public void updatePaymentTid(String paymentTid) {
-        this.paymentTid = paymentTid;
-    }
-
-    public void markPaid(String paymentMethod) {
-        this.paymentMethod = paymentMethod;
-        this.paidAt = LocalDateTime.now();
-        this.status = OrderStatus.PAID;
-    }
 
     @PrePersist
     protected void prePersist() {
@@ -127,6 +108,42 @@ public class Reservation extends BaseEntity {
         }
     }
 
+    /**
+     * 카카오페이 결제 준비 완료
+     * - ready API 응답으로 받은 tid 저장
+     * - 결제 진행 가능 상태로 변경
+     */
+    public void markPaymentReady(String paymentTid, String paymentMethod) {
+        this.paymentTid = paymentTid;
+        this.paymentMethod = paymentMethod;
+        this.paymentStatus = PaymentStatus.READY;
+    }
+
+    /**
+     * 카카오페이 결제 승인 완료
+     */
+    public void markPaid(String paymentMethod) {
+        this.paymentMethod = paymentMethod;
+        this.paymentStatus = PaymentStatus.PAID;
+        this.paidAt = LocalDateTime.now();
+    }
+
+    /**
+     * 결제 실패 처리
+     * - 예약 자체는 유지하고 결제 상태만 FAILED 처리
+     */
+    public void markPaymentFailed() {
+        this.paymentStatus = PaymentStatus.FAILED;
+    }
+
+    /**
+     * 결제 취소 처리
+     * - 예약 자체는 유지하고 결제 상태만 CANCELED 처리
+     */
+    public void cancelPayment() {
+        this.paymentStatus = PaymentStatus.CANCELED;
+    }
+
     public void approve() {
         this.status = ReservationStatus.APPROVED;
         this.rejectReason = null;
@@ -138,24 +155,12 @@ public class Reservation extends BaseEntity {
         this.pickupStatus = PickupStatus.WAITING;
     }
 
-    public void confirmDeposit() {
-        this.paymentStatus = PaymentStatus.PAID;
-    }
-
     public void markPreparing() {
         this.pickupStatus = PickupStatus.PREPARING;
     }
 
-    public void markReady() {
-        this.pickupStatus = PickupStatus.READY;
-    }
-
     public void markPickedUp() {
         this.pickupStatus = PickupStatus.PICKED_UP;
-    }
-
-    public void cancel(String reason) {
-        this.status = ReservationStatus.CANCELED;
-        this.rejectReason = reason;
+        this.pickedUpAt = LocalDateTime.now();
     }
 }

--- a/src/main/java/Comprehensive_Design_Project/CUK_Compasser/domain/reservation/repository/ReservationRepository.java
+++ b/src/main/java/Comprehensive_Design_Project/CUK_Compasser/domain/reservation/repository/ReservationRepository.java
@@ -37,6 +37,8 @@ public interface ReservationRepository extends JpaRepository<Reservation, Long> 
 
     boolean existsByRandomBox_IdAndMember_IdAndStatusIn(Long randomBoxId, Long memberId, List<ReservationStatus> statuses);
 
+    Optional<Reservation> findByIdAndMember_Id(Long reservationId, Long memberId);
+
     /// ////////
     @EntityGraph(attributePaths = {
             "member",
@@ -45,4 +47,5 @@ public interface ReservationRepository extends JpaRepository<Reservation, Long> 
             "randomBox"
     })
     Optional<Reservation> findByIdAndMember(Long reservationId, Member member);
+
 }

--- a/src/main/java/Comprehensive_Design_Project/CUK_Compasser/domain/reservation/service/KakaoPayClient.java
+++ b/src/main/java/Comprehensive_Design_Project/CUK_Compasser/domain/reservation/service/KakaoPayClient.java
@@ -1,0 +1,69 @@
+package Comprehensive_Design_Project.CUK_Compasser.domain.reservation.service;
+
+import Comprehensive_Design_Project.CUK_Compasser.domain.reservation.dto.KakaoPayReqDTO;
+import Comprehensive_Design_Project.CUK_Compasser.domain.reservation.dto.KakaoPayRespDTO;
+import Comprehensive_Design_Project.CUK_Compasser.global.common.apiPayload.code.status.ErrorStatus;
+import Comprehensive_Design_Project.CUK_Compasser.global.common.apiPayload.exception.GeneralException;
+import Comprehensive_Design_Project.CUK_Compasser.global.config.KakaoPayProperties;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.http.HttpHeaders;
+import org.springframework.http.MediaType;
+import org.springframework.stereotype.Component;
+import org.springframework.web.reactive.function.client.WebClient;
+
+@Slf4j
+@Component
+@RequiredArgsConstructor
+public class KakaoPayClient {
+
+    private final WebClient kakaoPayWebClient;
+    private final KakaoPayProperties kakaoPayProperties;
+
+    public KakaoPayRespDTO.ReadyResponseDTO ready(KakaoPayReqDTO.ReadyRequestDTO request) {
+        try {
+            log.info("[KakaoPayClient] ready 호출 시작 - url={}",
+                    kakaoPayProperties.getBaseUrl() + "/online/v1/payment/ready");
+
+            KakaoPayRespDTO.ReadyResponseDTO response = kakaoPayWebClient.post()
+                    .uri(kakaoPayProperties.getBaseUrl() + "/online/v1/payment/ready")
+                    .header(HttpHeaders.AUTHORIZATION, "SECRET_KEY " + kakaoPayProperties.getSecretKey())
+                    .contentType(MediaType.APPLICATION_JSON)
+                    .bodyValue(request)
+                    .retrieve()
+                    .bodyToMono(KakaoPayRespDTO.ReadyResponseDTO.class)
+                    .block(java.time.Duration.ofSeconds(10));
+
+            if (response == null) {
+                log.error("[KakaoPayClient] ready 응답이 null");
+                throw new GeneralException(ErrorStatus.KAKAOPAY_READY_FAILED);
+            }
+
+            log.info("[KakaoPayClient] ready 호출 성공 - tid={}", response.getTid());
+            return response;
+
+        } catch (org.springframework.web.reactive.function.client.WebClientResponseException e) {
+            log.error("[KakaoPayClient] ready 실패 - status={}, body={}",
+                    e.getStatusCode(), e.getResponseBodyAsString(), e);
+            throw new GeneralException(ErrorStatus.KAKAOPAY_READY_FAILED);
+        } catch (Exception e) {
+            log.error("[KakaoPayClient] ready 호출 실패", e);
+            throw new GeneralException(ErrorStatus.KAKAOPAY_READY_FAILED);
+        }
+    }
+
+    public KakaoPayRespDTO.ApproveResponseDTO approve(KakaoPayReqDTO.ApproveRequestDTO request) {
+        try {
+            return kakaoPayWebClient.post()
+                    .uri(kakaoPayProperties.getBaseUrl() + "/online/v1/payment/approve")
+                    .header(HttpHeaders.AUTHORIZATION, "SECRET_KEY " + kakaoPayProperties.getSecretKey())
+                    .contentType(MediaType.APPLICATION_JSON)
+                    .bodyValue(request)
+                    .retrieve()
+                    .bodyToMono(KakaoPayRespDTO.ApproveResponseDTO.class)
+                    .block();
+        } catch (Exception e) {
+            throw new GeneralException(ErrorStatus.KAKAOPAY_APPROVE_FAILED);
+        }
+    }
+}

--- a/src/main/java/Comprehensive_Design_Project/CUK_Compasser/domain/reservation/service/ReservationService.java
+++ b/src/main/java/Comprehensive_Design_Project/CUK_Compasser/domain/reservation/service/ReservationService.java
@@ -1,5 +1,6 @@
 package Comprehensive_Design_Project.CUK_Compasser.domain.reservation.service;
 
+import Comprehensive_Design_Project.CUK_Compasser.domain.reservation.dto.KakaoPayRespDTO;
 import Comprehensive_Design_Project.CUK_Compasser.domain.reservation.dto.ReservationReqDTO;
 import Comprehensive_Design_Project.CUK_Compasser.domain.reservation.dto.ReservationRespDTO;
 
@@ -11,6 +12,11 @@ public interface ReservationService {
 
     ReservationRespDTO.ReservationDTO approveReservation(Long reservationId, Long memberId);
 
-    ReservationRespDTO.ReservationDTO rejectReservation(Long reservationId, Long memberId,
-                                                        ReservationReqDTO request);
+    ReservationRespDTO.ReservationDTO rejectReservation(Long reservationId, Long memberId, ReservationReqDTO request);
+
+    KakaoPayRespDTO.ReadyResultDTO readyKakaoPay(Long reservationId, Long memberId);
+
+    KakaoPayRespDTO.ApproveResultDTO approveKakaoPay(Long reservationId, Long memberId, String pgToken);
+
+    void cancelKakaoPay(Long reservationId, Long memberId);
 }

--- a/src/main/java/Comprehensive_Design_Project/CUK_Compasser/domain/reservation/service/ReservationServiceImpl.java
+++ b/src/main/java/Comprehensive_Design_Project/CUK_Compasser/domain/reservation/service/ReservationServiceImpl.java
@@ -3,18 +3,21 @@ package Comprehensive_Design_Project.CUK_Compasser.domain.reservation.service;
 import Comprehensive_Design_Project.CUK_Compasser.domain.randomBox.entity.RandomBox;
 import Comprehensive_Design_Project.CUK_Compasser.domain.randomBox.repository.RandomBoxRepository;
 import Comprehensive_Design_Project.CUK_Compasser.domain.reservation.converter.ReservationConverter;
+import Comprehensive_Design_Project.CUK_Compasser.domain.reservation.dto.KakaoPayReqDTO;
+import Comprehensive_Design_Project.CUK_Compasser.domain.reservation.dto.KakaoPayRespDTO;
 import Comprehensive_Design_Project.CUK_Compasser.domain.reservation.dto.ReservationReqDTO;
 import Comprehensive_Design_Project.CUK_Compasser.domain.reservation.dto.ReservationRespDTO;
-import Comprehensive_Design_Project.CUK_Compasser.domain.reservation.entity.PickupStatus;
-import Comprehensive_Design_Project.CUK_Compasser.domain.reservation.entity.Reservation;
-import Comprehensive_Design_Project.CUK_Compasser.domain.reservation.entity.ReservationStatus;
+import Comprehensive_Design_Project.CUK_Compasser.domain.reservation.entity.*;
 import Comprehensive_Design_Project.CUK_Compasser.domain.reservation.repository.ReservationRepository;
 import Comprehensive_Design_Project.CUK_Compasser.domain.store.entity.Store;
 import Comprehensive_Design_Project.CUK_Compasser.domain.store.repository.StoreRepository;
 import Comprehensive_Design_Project.CUK_Compasser.global.common.apiPayload.code.status.ErrorStatus;
 import Comprehensive_Design_Project.CUK_Compasser.global.common.apiPayload.exception.GeneralException;
+import Comprehensive_Design_Project.CUK_Compasser.global.config.KakaoPayProperties;
 import lombok.RequiredArgsConstructor;
+import org.springframework.context.annotation.Lazy;
 import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Propagation;
 import org.springframework.transaction.annotation.Transactional;
 import org.springframework.util.StringUtils;
 
@@ -29,22 +32,15 @@ public class ReservationServiceImpl implements ReservationService {
     private final StoreRepository storeRepository;
     private final RandomBoxRepository randomBoxRepository;
     private final ReservationConverter reservationConverter;
+    private final KakaoPayClient kakaoPayClient;
+    private final KakaoPayProperties kakaoPayProperties;
 
-    /**
-     * 예약 페이지 목록 조회
-     *
-     * - 예약 페이지에는 확인 대기중인 예약만 보여준다.
-     * - 즉 REQUESTED 상태의 예약만 조회한다.
-     *
-     * 처리 흐름:
-     * 1. 현재 로그인한 점장의 가게를 찾는다.
-     * 2. 해당 가게의 REQUESTED 상태 예약만 최신순으로 조회한다.
-     * 3. 화면 응답 DTO로 변환해서 반환한다.
-     */
+    @Lazy
+    private final ReservationServiceImpl self;
+
     @Override
     @Transactional(readOnly = true)
     public ReservationRespDTO.ReservationListDTO getPendingReservations(Long memberId) {
-
         Store store = storeRepository.findByStoreManager_MemberId(memberId)
                 .orElseThrow(() -> new GeneralException(ErrorStatus.STORE_NOT_FOUND));
 
@@ -56,17 +52,6 @@ public class ReservationServiceImpl implements ReservationService {
         return reservationConverter.toReservationListDTO(reservations);
     }
 
-    /**
-     * 주문 페이지 목록 조회
-     *
-     * - 주문 페이지에는 처리 완료된 예약만 보여준다.
-     * - 즉 APPROVED, REJECTED, CANCELED 상태를 조회한다.
-     *
-     * 처리 흐름:
-     * 1. 현재 로그인한 점장의 가게를 찾는다.
-     * 2. 해당 가게의 처리 완료 상태 예약만 최신순으로 조회한다.
-     * 3. 화면 응답 DTO로 변환해서 반환한다.
-     */
     @Override
     @Transactional(readOnly = true)
     public ReservationRespDTO.ReservationListDTO getProcessedReservations(Long memberId) {
@@ -87,85 +72,43 @@ public class ReservationServiceImpl implements ReservationService {
         return reservationConverter.toReservationListDTO(reservations);
     }
 
-    /**
-     * 예약 수락
-     *
-     * - REQUESTED 상태의 예약만 APPROVED로 변경할 수 있다.
-     * - 승인 시 해당 예약 수량만큼 랜덤박스 재고를 차감한다.
-     * - 재고가 부족하면 승인할 수 없다.
-     * - 동시 승인 상황에서 재고 꼬임을 막기 위해 RandomBox는 락을 걸고 조회한다.
-     *
-     * 처리 흐름:
-     * 1. 현재 로그인한 점장의 가게를 찾는다.
-     * 2. 해당 가게에 속한 예약인지 확인한다.
-     * 3. 현재 예약 상태가 REQUESTED인지 검증한다.
-     * 4. 연결된 RandomBox를 락(PESSIMISTIC_WRITE)으로 다시 조회한다.
-     * 5. 요청 수량만큼 재고를 차감한다.
-     * 6. 예약 상태를 APPROVED로 변경한다.
-     * 7. 변경된 예약을 DTO로 변환해 반환한다.
-     */
     @Override
     @Transactional
     public ReservationRespDTO.ReservationDTO approveReservation(Long reservationId, Long memberId) {
-        // 현재 로그인한 점주의 가게 조회
         Store store = storeRepository.findByStoreManager_MemberId(memberId)
                 .orElseThrow(() -> new GeneralException(ErrorStatus.STORE_NOT_FOUND));
 
-        // 해당 가게의 예약인지 확인하면서 예약 조회
         Reservation reservation = reservationRepository.findByIdAndStore_Id(reservationId, store.getId())
                 .orElseThrow(() -> new GeneralException(ErrorStatus.RESERVATION_NOT_FOUND));
 
         ReservationStatus currentStatus = reservation.getStatus();
 
-        // 이미 픽업이 끝난 예약은 상태 변경 불가
         if (reservation.getPickupStatus() == PickupStatus.PICKED_UP) {
             throw new GeneralException(ErrorStatus.RESERVATION_ALREADY_PICKED_UP);
         }
 
-        // 사용자가 취소한 예약은 점주가 다시 처리할 수 없음
         if (currentStatus == ReservationStatus.CANCELED) {
             throw new GeneralException(ErrorStatus.INVALID_RESERVATION_STATUS);
         }
 
-        // 이미 승인된 예약은 다시 승인하지 않음
         if (currentStatus == ReservationStatus.APPROVED) {
             throw new GeneralException(ErrorStatus.RESERVATION_ALREADY_APPROVED);
         }
 
-        // 승인 시점에만 실제 재고를 차감해야 하므로 락을 걸고 랜덤박스 재조회
         RandomBox lockedRandomBox = randomBoxRepository.findWithLockById(reservation.getRandomBox().getId())
                 .orElseThrow(() -> new GeneralException(ErrorStatus.RANDOM_BOX_NOT_FOUND));
 
-        // 재고 차감
-        // 차감 후 0개가 되면 RandomBox 내부에서 자동으로 SOLD_OUT 처리
         lockedRandomBox.decreaseStock(reservation.getRequestedQuantity());
 
-        // 예약 승인 처리
         reservation.approve();
-
-        // 승인 후 상품 준비중 상태로 변경
         reservation.markPreparing();
 
         return reservationConverter.toReservationDTO(reservation);
     }
-    /**
-     * 예약 거절
-     *
-     * - REQUESTED 상태의 예약만 거절할 수 있다.
-     * - 거절 사유는 필수다.
-     *
-     * 처리 흐름:
-     * 1. 현재 로그인한 점장의 가게를 찾는다.
-     * 2. 해당 가게에 속한 예약인지 확인한다.
-     * 3. 현재 예약 상태가 REQUESTED인지 검증한다.
-     * 4. 거절 사유가 비어 있지 않은지 확인한다.
-     * 5. 예약 상태를 REJECTED로 변경하고 거절 사유를 저장한다.
-     * 6. 변경된 예약을 DTO로 변환해 반환한다.
-     */
+
     @Override
     @Transactional
-    public ReservationRespDTO.ReservationDTO rejectReservation(Long reservationId, Long memberId,
-                                                               ReservationReqDTO request) {
+    public ReservationRespDTO.ReservationDTO rejectReservation(Long reservationId, Long memberId, ReservationReqDTO request) {
         Store store = storeRepository.findByStoreManager_MemberId(memberId)
                 .orElseThrow(() -> new GeneralException(ErrorStatus.STORE_NOT_FOUND));
 
@@ -174,28 +117,22 @@ public class ReservationServiceImpl implements ReservationService {
 
         ReservationStatus currentStatus = reservation.getStatus();
 
-        // 거절 사유 필수
         if (request.getRejectReason() == null || request.getRejectReason().trim().isEmpty()) {
             throw new GeneralException(ErrorStatus.REJECT_REASON_REQUIRED);
         }
 
-        // 이미 픽업 완료된 예약은 변경 불가
         if (reservation.getPickupStatus() == PickupStatus.PICKED_UP) {
             throw new GeneralException(ErrorStatus.RESERVATION_ALREADY_PICKED_UP);
         }
 
-        // 사용자가 이미 취소한 예약은 점주가 건드리지 못하게 막음
         if (currentStatus == ReservationStatus.CANCELED) {
             throw new GeneralException(ErrorStatus.INVALID_RESERVATION_STATUS);
         }
 
-        // 이미 거절 상태면 중복 거절 방지
         if (currentStatus == ReservationStatus.REJECTED) {
             throw new GeneralException(ErrorStatus.RESERVATION_ALREADY_REJECTED);
         }
 
-        // APPROVED -> REJECTED
-        // 승인하면서 차감했던 재고를 복구해야 함
         if (currentStatus == ReservationStatus.APPROVED) {
             RandomBox lockedRandomBox = randomBoxRepository.findWithLockById(reservation.getRandomBox().getId())
                     .orElseThrow(() -> new GeneralException(ErrorStatus.RANDOM_BOX_NOT_FOUND));
@@ -203,9 +140,152 @@ public class ReservationServiceImpl implements ReservationService {
             lockedRandomBox.increaseStock(reservation.getRequestedQuantity());
         }
 
-        // REQUESTED -> REJECTED 는 재고 변화 없음
         reservation.reject(request.getRejectReason());
 
         return reservationConverter.toReservationDTO(reservation);
+    }
+
+    @Override
+    @Transactional
+    public KakaoPayRespDTO.ReadyResultDTO readyKakaoPay(Long reservationId, Long memberId) {
+        Reservation reservation = reservationRepository.findByIdAndMember_Id(reservationId, memberId)
+                .orElseThrow(() -> new GeneralException(ErrorStatus.RESERVATION_NOT_FOUND));
+
+        if (reservation.getPaymentStatus() == PaymentStatus.PAID) {
+            throw new GeneralException(ErrorStatus.RESERVATION_ALREADY_PAID);
+        }
+
+        if (reservation.getStatus() == ReservationStatus.CANCELED ||
+                reservation.getStatus() == ReservationStatus.REJECTED) {
+            throw new GeneralException(ErrorStatus.INVALID_RESERVATION_STATUS);
+        }
+
+        String partnerOrderId = "reservation_" + reservation.getId();
+        String partnerUserId = "member_" + memberId;
+
+        KakaoPayReqDTO.ReadyRequestDTO request = KakaoPayReqDTO.ReadyRequestDTO.builder()
+                .cid(kakaoPayProperties.getCid())
+                .partner_order_id(partnerOrderId)
+                .partner_user_id(partnerUserId)
+                .item_name(reservation.getStore().getStoreName() + " 랜덤박스")
+                .quantity(reservation.getRequestedQuantity())
+                .total_amount(reservation.getTotalPrice())
+                .tax_free_amount(0)
+                .approval_url(kakaoPayProperties.getApprovalUrl() + "?reservationId=" + reservation.getId())
+                .cancel_url(kakaoPayProperties.getCancelUrl() + "?reservationId=" + reservation.getId())
+                .fail_url(kakaoPayProperties.getFailUrl() + "?reservationId=" + reservation.getId())
+                .build();
+
+        KakaoPayRespDTO.ReadyResponseDTO response = kakaoPayClient.ready(request);
+
+        reservation.markPaymentReady(response.getTid(), "KAKAOPAY");
+
+        return KakaoPayRespDTO.ReadyResultDTO.builder()
+                .reservationId(reservation.getId())
+                .tid(response.getTid())
+                .redirectUrl(response.getNext_redirect_pc_url())
+                .paymentStatus(reservation.getPaymentStatus().name())
+                .build();
+    }
+
+    @Override
+    @Transactional
+    public KakaoPayRespDTO.ApproveResultDTO approveKakaoPay(Long reservationId, Long memberId, String pgToken) {
+        if (!StringUtils.hasText(pgToken)) {
+            throw new GeneralException(ErrorStatus.INVALID_PG_TOKEN);
+        }
+
+        Reservation reservation = reservationRepository.findByIdAndMember_Id(reservationId, memberId)
+                .orElseThrow(() -> new GeneralException(ErrorStatus.RESERVATION_NOT_FOUND));
+
+        if (reservation.getStatus() == ReservationStatus.CANCELED ||
+                reservation.getStatus() == ReservationStatus.REJECTED) {
+            throw new GeneralException(ErrorStatus.INVALID_RESERVATION_STATUS);
+        }
+
+        if (!StringUtils.hasText(reservation.getPaymentTid())) {
+            throw new GeneralException(ErrorStatus.PAYMENT_TID_NOT_FOUND);
+        }
+
+        if (reservation.getPaymentStatus() == PaymentStatus.PAID) {
+            throw new GeneralException(ErrorStatus.RESERVATION_ALREADY_PAID);
+        }
+
+        if (reservation.getPaymentStatus() != PaymentStatus.READY) {
+            throw new GeneralException(ErrorStatus.INVALID_PAYMENT_STATUS);
+        }
+
+        try {
+            KakaoPayReqDTO.ApproveRequestDTO request = KakaoPayReqDTO.ApproveRequestDTO.builder()
+                    .cid(kakaoPayProperties.getCid())
+                    .tid(reservation.getPaymentTid())
+                    .partner_order_id("reservation_" + reservation.getId())
+                    .partner_user_id("member_" + memberId)
+                    .pg_token(pgToken)
+                    .build();
+
+            KakaoPayRespDTO.ApproveResponseDTO response = kakaoPayClient.approve(request);
+
+            validateApproveResponse(reservation, response);
+
+            reservation.markPaid("KAKAOPAY");
+
+            return KakaoPayRespDTO.ApproveResultDTO.builder()
+                    .reservationId(reservation.getId())
+                    .paymentMethod(reservation.getPaymentMethod())
+                    .paymentStatus(reservation.getPaymentStatus().name())
+                    .approvedAt(response.getApproved_at())
+                    .build();
+
+        } catch (GeneralException e) {
+            self.markPaymentFailedInNewTx(reservation.getId());
+            throw e;
+        } catch (Exception e) {
+            self.markPaymentFailedInNewTx(reservation.getId());
+            throw new GeneralException(ErrorStatus.KAKAOPAY_APPROVE_FAILED);
+        }
+    }
+
+    @Transactional(propagation = Propagation.REQUIRES_NEW)
+    public void markPaymentFailedInNewTx(Long reservationId) {
+        Reservation reservation = reservationRepository.findById(reservationId)
+                .orElseThrow(() -> new GeneralException(ErrorStatus.RESERVATION_NOT_FOUND));
+
+        reservation.markPaymentFailed();
+    }
+
+    private void validateApproveResponse(Reservation reservation, KakaoPayRespDTO.ApproveResponseDTO response) {
+        if (response == null || response.getAmount() == null || response.getAmount().getTotal() == null) {
+            throw new GeneralException(ErrorStatus.INVALID_PAYMENT_AMOUNT);
+        }
+
+        Integer approvedAmount = response.getAmount().getTotal();
+        Integer expectedAmount = reservation.getTotalPrice();
+
+        if (!expectedAmount.equals(approvedAmount)) {
+            throw new GeneralException(ErrorStatus.INVALID_PAYMENT_AMOUNT);
+        }
+
+        if (!reservation.getPaymentTid().equals(response.getTid())) {
+            throw new GeneralException(ErrorStatus.INVALID_PAYMENT_INFO);
+        }
+
+        String expectedPartnerOrderId = "reservation_" + reservation.getId();
+        if (!expectedPartnerOrderId.equals(response.getPartner_order_id())) {
+            throw new GeneralException(ErrorStatus.INVALID_PAYMENT_INFO);
+        }
+    }
+
+    @Override
+    @Transactional
+    public void cancelKakaoPay(Long reservationId, Long memberId) {
+        Reservation reservation = reservationRepository.findByIdAndMember_Id(reservationId, memberId)
+                .orElseThrow(() -> new GeneralException(ErrorStatus.RESERVATION_NOT_FOUND));
+
+        if (reservation.getPaymentStatus() == PaymentStatus.PAID) {
+            throw new GeneralException(ErrorStatus.RESERVATION_ALREADY_PAID);
+        }
+
+        reservation.cancelPayment();
     }
 }

--- a/src/main/java/Comprehensive_Design_Project/CUK_Compasser/domain/reservation/service/ReservationServiceImpl.java
+++ b/src/main/java/Comprehensive_Design_Project/CUK_Compasser/domain/reservation/service/ReservationServiceImpl.java
@@ -15,10 +15,11 @@ import Comprehensive_Design_Project.CUK_Compasser.global.common.apiPayload.code.
 import Comprehensive_Design_Project.CUK_Compasser.global.common.apiPayload.exception.GeneralException;
 import Comprehensive_Design_Project.CUK_Compasser.global.config.KakaoPayProperties;
 import lombok.RequiredArgsConstructor;
-import org.springframework.context.annotation.Lazy;
 import org.springframework.stereotype.Service;
-import org.springframework.transaction.annotation.Propagation;
+import org.springframework.transaction.PlatformTransactionManager;
+import org.springframework.transaction.TransactionDefinition;
 import org.springframework.transaction.annotation.Transactional;
+import org.springframework.transaction.support.TransactionTemplate;
 import org.springframework.util.StringUtils;
 
 import java.util.List;
@@ -34,9 +35,7 @@ public class ReservationServiceImpl implements ReservationService {
     private final ReservationConverter reservationConverter;
     private final KakaoPayClient kakaoPayClient;
     private final KakaoPayProperties kakaoPayProperties;
-
-    @Lazy
-    private final ReservationServiceImpl self;
+    private final PlatformTransactionManager transactionManager;
 
     @Override
     @Transactional(readOnly = true)
@@ -238,20 +237,24 @@ public class ReservationServiceImpl implements ReservationService {
                     .build();
 
         } catch (GeneralException e) {
-            self.markPaymentFailedInNewTx(reservation.getId());
+            markPaymentFailedInNewTx(reservation.getId());
             throw e;
         } catch (Exception e) {
-            self.markPaymentFailedInNewTx(reservation.getId());
+            markPaymentFailedInNewTx(reservation.getId());
             throw new GeneralException(ErrorStatus.KAKAOPAY_APPROVE_FAILED);
         }
     }
 
-    @Transactional(propagation = Propagation.REQUIRES_NEW)
-    public void markPaymentFailedInNewTx(Long reservationId) {
-        Reservation reservation = reservationRepository.findById(reservationId)
-                .orElseThrow(() -> new GeneralException(ErrorStatus.RESERVATION_NOT_FOUND));
+    private void markPaymentFailedInNewTx(Long reservationId) {
+        TransactionTemplate txTemplate = new TransactionTemplate(transactionManager);
+        txTemplate.setPropagationBehavior(TransactionDefinition.PROPAGATION_REQUIRES_NEW);
 
-        reservation.markPaymentFailed();
+        txTemplate.executeWithoutResult(status -> {
+            Reservation failedReservation = reservationRepository.findById(reservationId)
+                    .orElseThrow(() -> new GeneralException(ErrorStatus.RESERVATION_NOT_FOUND));
+
+            failedReservation.markPaymentFailed();
+        });
     }
 
     private void validateApproveResponse(Reservation reservation, KakaoPayRespDTO.ApproveResponseDTO response) {

--- a/src/main/java/Comprehensive_Design_Project/CUK_Compasser/global/common/apiPayload/code/status/ErrorStatus.java
+++ b/src/main/java/Comprehensive_Design_Project/CUK_Compasser/global/common/apiPayload/code/status/ErrorStatus.java
@@ -101,6 +101,7 @@ public enum ErrorStatus implements BaseErrorCode {
     RESERVATION_ALREADY_APPROVED(HttpStatus.BAD_REQUEST, "R006", "이미 승인된 예약입니다."),
     RESERVATION_ALREADY_REJECTED(HttpStatus.BAD_REQUEST, "R007", "이미 거절된 예약입니다."),
     RESERVATION_ALREADY_PICKED_UP(HttpStatus.BAD_REQUEST, "R008", "이미 픽업된 예약입니다."),
+    RESERVATION_ALREADY_PAID(HttpStatus.CONFLICT, "R010", "이미 결제가 완료된 예약입니다."),
 
 
     // =========================
@@ -108,8 +109,18 @@ public enum ErrorStatus implements BaseErrorCode {
     // =========================
     INVALID_ORDER_QUANTITY(HttpStatus.BAD_REQUEST, "O001", "주문 수량이 올바르지 않습니다."),
     ORDER_ALREADY_PAID(HttpStatus.BAD_REQUEST, "O002", "이미 송금 완료 처리된 주문입니다."),
-    ORDER_CANCEL_NOT_ALLOWED(HttpStatus.BAD_REQUEST, "O003", "현재 상태의 주문은 취소할 수 없습니다.");
+    ORDER_CANCEL_NOT_ALLOWED(HttpStatus.BAD_REQUEST, "O003", "현재 상태의 주문은 취소할 수 없습니다."),
 
+    // =========================
+    // [Payment]
+    // =========================
+    KAKAOPAY_READY_FAILED(HttpStatus.BAD_GATEWAY, "P001", "카카오페이 결제 준비에 실패했습니다."),
+    KAKAOPAY_APPROVE_FAILED(HttpStatus.BAD_GATEWAY, "P002", "카카오페이 결제 승인에 실패했습니다."),
+    PAYMENT_TID_NOT_FOUND(HttpStatus.NOT_FOUND, "P003", "결제 TID를 찾을 수 없습니다."),
+    INVALID_PG_TOKEN(HttpStatus.BAD_REQUEST, "P004", "유효하지 않은 pg_token 입니다."),
+    INVALID_PAYMENT_STATUS(HttpStatus.BAD_REQUEST, "P005", "현재 결제 상태에서는 요청할 수 없습니다."),
+    INVALID_PAYMENT_AMOUNT(HttpStatus.BAD_REQUEST, "P006", "결제 금액이 주문 금액과 일치하지 않습니다."),
+    INVALID_PAYMENT_INFO(HttpStatus.BAD_REQUEST, "P007", "결제 승인 정보가 올바르지 않습니다.");
 
     private final HttpStatus httpStatus;
     private final String code;

--- a/src/main/java/Comprehensive_Design_Project/CUK_Compasser/global/common/apiPayload/code/status/SuccessStatus.java
+++ b/src/main/java/Comprehensive_Design_Project/CUK_Compasser/global/common/apiPayload/code/status/SuccessStatus.java
@@ -17,7 +17,13 @@ public enum SuccessStatus implements BaseSuccessCode {
     ORDER_CREATED(HttpStatus.CREATED, "O2001", "주문 생성에 성공했습니다."),
     ORDER_COMPLETED(HttpStatus.OK, "O2002", "결제 진행 정보 저장에 성공했습니다."),
     ORDER_STATUS_FOUND(HttpStatus.OK, "O2003", "주문 상태 조회에 성공했습니다."),
-    ORDER_CANCELED(HttpStatus.OK, "ORDER2004", "주문 취소에 성공했습니다.");
+    ORDER_CANCELED(HttpStatus.OK, "ORDER2004", "주문 취소에 성공했습니다."),
+
+    // =========================
+    // [Payment]
+    // =========================
+    RESERVATION_PAYMENT_READY(HttpStatus.OK, "R2004", "카카오페이 결제 준비에 성공했습니다."),
+    RESERVATION_PAYMENT_APPROVED(HttpStatus.OK, "R2005", "카카오페이 결제 승인에 성공했습니다.");
 
     private final HttpStatus httpStatus;
     private final String code;

--- a/src/main/java/Comprehensive_Design_Project/CUK_Compasser/global/config/KakaoLocalWebClientConfig.java
+++ b/src/main/java/Comprehensive_Design_Project/CUK_Compasser/global/config/KakaoLocalWebClientConfig.java
@@ -8,7 +8,7 @@ import org.springframework.web.reactive.function.client.WebClient;
 
 @Configuration
 @RequiredArgsConstructor
-public class KakaoWebClientConfig {
+public class KakaoLocalWebClientConfig {
 
     @Value("${kakao.local.base-url}")
     private String baseUrl;

--- a/src/main/java/Comprehensive_Design_Project/CUK_Compasser/global/config/KakaoPayProperties.java
+++ b/src/main/java/Comprehensive_Design_Project/CUK_Compasser/global/config/KakaoPayProperties.java
@@ -1,0 +1,19 @@
+package Comprehensive_Design_Project.CUK_Compasser.global.config;
+
+import lombok.Getter;
+import lombok.Setter;
+import org.springframework.boot.context.properties.ConfigurationProperties;
+import org.springframework.stereotype.Component;
+
+@Getter
+@Setter
+@Component
+@ConfigurationProperties(prefix = "kakaopay")
+public class KakaoPayProperties {
+    private String cid;
+    private String secretKey;
+    private String baseUrl;
+    private String approvalUrl;
+    private String cancelUrl;
+    private String failUrl;
+}

--- a/src/main/java/Comprehensive_Design_Project/CUK_Compasser/global/config/KakaoPayProperties.java
+++ b/src/main/java/Comprehensive_Design_Project/CUK_Compasser/global/config/KakaoPayProperties.java
@@ -10,6 +10,7 @@ import org.springframework.stereotype.Component;
 @Component
 @ConfigurationProperties(prefix = "kakaopay")
 public class KakaoPayProperties {
+
     private String cid;
     private String secretKey;
     private String baseUrl;

--- a/src/main/java/Comprehensive_Design_Project/CUK_Compasser/global/config/KakaoPayWebClientConfig.java
+++ b/src/main/java/Comprehensive_Design_Project/CUK_Compasser/global/config/KakaoPayWebClientConfig.java
@@ -1,0 +1,14 @@
+package Comprehensive_Design_Project.CUK_Compasser.global.config;
+
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.web.reactive.function.client.WebClient;
+
+@Configuration
+public class KakaoPayWebClientConfig {
+
+    @Bean
+    public WebClient kakaoPayWebClient() {
+        return WebClient.builder().build();
+    }
+}

--- a/src/main/java/Comprehensive_Design_Project/CUK_Compasser/global/config/KakaoPayWebClientConfig.java
+++ b/src/main/java/Comprehensive_Design_Project/CUK_Compasser/global/config/KakaoPayWebClientConfig.java
@@ -8,7 +8,7 @@ import org.springframework.web.reactive.function.client.WebClient;
 public class KakaoPayWebClientConfig {
 
     @Bean
-    public WebClient kakaoPayWebClient() {
-        return WebClient.builder().build();
+    public WebClient kakaoPayWebClient(WebClient.Builder builder) {
+        return builder.build();
     }
 }

--- a/src/main/resources/application-local.yml
+++ b/src/main/resources/application-local.yml
@@ -106,6 +106,13 @@ kakao:
     base-url: https://dapi.kakao.com
     rest-api-key: ${KAKAO_REST_API_KEY}
 
+kakaopay:
+  cid: TC0ONETIME
+  secret-key: ${KAKAOPAY_SECRET_KEY_DEV}
+  base-url: https://open-api.kakaopay.com
+  approval-url: https://compasser.co.kr/payments/kakaopay/success
+  cancel-url: https://compasser.co.kr/payments/kakaopay/cancel
+  fail-url: https://compasser.co.kr/payments/kakaopay/fail
 
 springdoc:
   packages-to-scan: Comprehensive_Design_Project.CUK_Compasser


### PR DESCRIPTION
## ❗Pull Request!

### 연관 이슈
- 

### 📝 작업 상세 내용
- 카카오페이 결제 연동 흐름을 주문 기준으로 정리했습니다.
- 결제 준비 API(`POST /orders/{orderId}/payment/ready`)를 구현해 카카오페이 결제창 진입에 필요한 `tid`, redirect 정보를 생성하도록 했습니다.
- 결제 승인 API(`POST /orders/{orderId}/payment/approve`)를 구현해 `pg_token` 기반 최종 승인 처리를 할 수 있도록 했습니다.
- 카카오페이 성공 콜백 API(`GET /payments/kakaopay/success`)를 구현해 승인 단계로 연결할 수 있도록 했습니다.
- 카카오페이 취소/실패 콜백 API 구조를 추가하고 흐름을 정리했습니다.
- 카카오페이 연동 디버깅을 위해 요청/응답 로그를 보강했습니다.
- 테스트 과정에서 카카오페이 `ready` 호출 시 도메인 검증 문제가 있음을 확인했고, redirect URL 및 base-url 설정을 점검했습니다.
- `base-url`은 카카오 API 서버(`https://open-api.kakaopay.com`)를 사용하고, `approval/cancel/fail url`은 서비스 도메인(`https://compasser.co.kr`)을 사용하도록 정리했습니다.

### ✅ 체크리스트
- [] 테스트를 거쳤나요?

### 🙋🏻‍♀️ 리뷰 요구사항 (optional)
- 카카오페이 결제 준비/승인 플로우와 callback URL 처리 방식 위주로 봐주시면 좋겠습니다.
- `base-url`과 redirect URL 역할을 분리한 부분이 맞는지 확인 부탁드립니다. > 카카오페이 개발자센터 페이지에서 작업함
- 취소/실패 콜백 이후 상태 처리 방식은 추가 구현 예정이라 구조 위주로 리뷰 부탁드립니다.