### PR TITLE
feat - 카카오페이 선결제 기반 주문/환불 및 수동 정산 구조 반영

### DIFF
--- a/src/main/java/Comprehensive_Design_Project/CUK_Compasser/domain/member/service/MemberService.java
+++ b/src/main/java/Comprehensive_Design_Project/CUK_Compasser/domain/member/service/MemberService.java
@@ -70,7 +70,6 @@ public class MemberService {
                 .orElseThrow(() -> new RuntimeException("해당 회원을 찾을 수 없습니다."));
 
         RewardSummary rewardSummary = rewardRepository.getRewardSummaryByMemberId(memberId);
-        Long totalUnboxing = orderRepository.countByMember_IdAndStatus(memberId, OrderStatus.PICKED_UP);
 
         return MemberRespDTO.MyPageRespDTO.builder()
                 .memberName(member.getMemberName())
@@ -79,7 +78,6 @@ public class MemberService {
                 .profileImageUrl(null) // 현재는 null 값
                 .totalStampCount((int) rewardSummary.earnCount())   // long -> int
                 .totalCouponCount((int) rewardSummary.couponCount()) // long -> int
-                .totalUnboxingCount(totalUnboxing != null ? totalUnboxing.intValue() : 0)
                 .build();
     }
 }

--- a/src/main/java/Comprehensive_Design_Project/CUK_Compasser/domain/order/converter/OrderStatusMapper.java
+++ b/src/main/java/Comprehensive_Design_Project/CUK_Compasser/domain/order/converter/OrderStatusMapper.java
@@ -26,7 +26,7 @@ public class OrderStatusMapper {
     /**
      * 사용자 주문 화면에 표시할 대표 상태를 계산하는 클래스
      *
-     * 실제 상태 원천은 ReservationStatus, PaymentStatus, PickupStatus이며,
+     * 실제 상태 원천은 ReservationStatus, PaymentStatus이며,
      * OrderStatus는 다른 코드와의 호환을 위해 대표 상태로만 사용한다.
      */
     public static OrderStatus resolve(Reservation reservation) {

--- a/src/main/java/Comprehensive_Design_Project/CUK_Compasser/domain/order/dto/OrderReqDTO.java
+++ b/src/main/java/Comprehensive_Design_Project/CUK_Compasser/domain/order/dto/OrderReqDTO.java
@@ -33,7 +33,6 @@ public class OrderReqDTO {
         // 실제 DB 상태값
         private String reservationStatus;
         private String paymentStatus;
-        private String pickupStatus;
 
         private String message;
     }

--- a/src/main/java/Comprehensive_Design_Project/CUK_Compasser/domain/order/dto/OrderRespDTO.java
+++ b/src/main/java/Comprehensive_Design_Project/CUK_Compasser/domain/order/dto/OrderRespDTO.java
@@ -29,7 +29,6 @@ public class OrderRespDTO {
         private String orderStatus;
         private String reservationStatus;
         private String paymentStatus;
-        private String pickupStatus;
 
         private BankType memberBankType;
 
@@ -50,7 +49,6 @@ public class OrderRespDTO {
         private String orderStatus;
         private String reservationStatus;
         private String paymentStatus;
-        private String pickupStatus;
         private String message;
     }
 
@@ -63,7 +61,6 @@ public class OrderRespDTO {
         private String orderStatus;
         private String reservationStatus;
         private String paymentStatus;
-        private String pickupStatus;
         private String message;
     }
 
@@ -85,7 +82,6 @@ public class OrderRespDTO {
         private String orderStatus;
         private String reservationStatus;
         private String paymentStatus;
-        private String pickupStatus;
 
         private BankType memberBankType;
 

--- a/src/main/java/Comprehensive_Design_Project/CUK_Compasser/domain/order/entity/OrderStatus.java
+++ b/src/main/java/Comprehensive_Design_Project/CUK_Compasser/domain/order/entity/OrderStatus.java
@@ -1,5 +1,5 @@
 package Comprehensive_Design_Project.CUK_Compasser.domain.order.entity;
 
 public enum OrderStatus {
-    CREATED, PAID, PREPARING, READY, PICKED_UP, CANCELED
+    CREATED, PAID, PREPARING, READY, CANCELED
 }

--- a/src/main/java/Comprehensive_Design_Project/CUK_Compasser/domain/order/service/OrderServiceImpl.java
+++ b/src/main/java/Comprehensive_Design_Project/CUK_Compasser/domain/order/service/OrderServiceImpl.java
@@ -86,12 +86,12 @@ public class OrderServiceImpl implements OrderService {
         validateCancelOrder(reservation);
 
         if (reservation.getPaymentStatus() == PaymentStatus.PAID) {
+            validateRefundable(reservation);
             cancelKakaoPayPayment(reservation);
             reservation.markRefunded();
         } else {
             reservation.setPaymentStatus(PaymentStatus.CANCELED);
         }
-
         reservation.setStatus(ReservationStatus.CANCELED);
 
         return OrderConverter.toCancelOrderResultDTO(
@@ -173,6 +173,12 @@ public class OrderServiceImpl implements OrderService {
 
         if (response == null || !reservation.getPaymentTid().equals(response.getTid())) {
             throw new GeneralException(ErrorStatus.INVALID_PAYMENT_INFO);
+        }
+    }
+
+    private void validateRefundable(Reservation reservation) {
+        if (Boolean.TRUE.equals(reservation.getSettled())) {
+            throw new GeneralException(ErrorStatus.REFUND_NOT_ALLOWED_AFTER_SETTLEMENT);
         }
     }
 }

--- a/src/main/java/Comprehensive_Design_Project/CUK_Compasser/domain/reservation/entity/Reservation.java
+++ b/src/main/java/Comprehensive_Design_Project/CUK_Compasser/domain/reservation/entity/Reservation.java
@@ -65,10 +65,6 @@ public class Reservation extends BaseEntity {
     @Column(name = "total_price", nullable = false)
     private Integer totalPrice;
 
-    // 픽업 완료 시각
-    @Column(name = "picked_up_at")
-    private LocalDateTime pickedUpAt;
-
     // 결제 상태
     @Builder.Default
     @Enumerated(EnumType.STRING)
@@ -91,6 +87,21 @@ public class Reservation extends BaseEntity {
     // 실제 결제 완료 시각
     @Column(name = "paid_at")
     private LocalDateTime paidAt;
+
+    @Column(nullable = false)
+    @Builder.Default
+    private Boolean settled = false;
+
+    private LocalDateTime settledAt;
+
+    public void markSettled() {
+        if (Boolean.TRUE.equals(this.settled)) {
+            throw new GeneralException(ErrorStatus.ALREADY_SETTLED);
+        }
+        this.settled = true;
+        this.settledAt = LocalDateTime.now();
+    }
+
 
     @PrePersist
     protected void prePersist() {
@@ -151,6 +162,9 @@ public class Reservation extends BaseEntity {
     public void markRefunded() {
         if (this.paymentStatus != PaymentStatus.PAID) {
             throw new GeneralException(ErrorStatus.INVALID_PAYMENT_STATUS);
+        }
+        if (Boolean.TRUE.equals(this.settled)) {
+            throw new GeneralException(ErrorStatus.REFUND_NOT_ALLOWED_AFTER_SETTLEMENT);
         }
         this.paymentStatus = PaymentStatus.REFUNDED;
     }

--- a/src/main/java/Comprehensive_Design_Project/CUK_Compasser/domain/reservation/repository/ReservationRepository.java
+++ b/src/main/java/Comprehensive_Design_Project/CUK_Compasser/domain/reservation/repository/ReservationRepository.java
@@ -1,6 +1,7 @@
 package Comprehensive_Design_Project.CUK_Compasser.domain.reservation.repository;
 
 import Comprehensive_Design_Project.CUK_Compasser.domain.member.entity.Member;
+import Comprehensive_Design_Project.CUK_Compasser.domain.reservation.entity.PaymentStatus;
 import Comprehensive_Design_Project.CUK_Compasser.domain.reservation.entity.Reservation;
 import Comprehensive_Design_Project.CUK_Compasser.domain.reservation.entity.ReservationStatus;
 import org.springframework.data.jpa.repository.EntityGraph;
@@ -40,4 +41,37 @@ public interface ReservationRepository extends JpaRepository<Reservation, Long> 
     })
     Optional<Reservation> findByIdAndMember(Long reservationId, Member member);
 
+    // =========================
+    // Settlement
+    // =========================
+
+    /**
+     * 정산 대상 조회
+     * - 점장 본인 가게의 주문 중
+     *   APPROVED + PAID + settled = false 인 주문만 조회한다.
+     */
+    @EntityGraph(attributePaths = {
+            "member",
+            "store",
+            "store.storeManager",
+            "randomBox"
+    })
+    List<Reservation> findAllByStore_IdAndStatusAndPaymentStatusAndSettledFalseOrderByCreatedAtAsc(
+            Long storeId,
+            ReservationStatus status,
+            PaymentStatus paymentStatus
+    );
+
+    /**
+     * 정산 완료 처리 대상 조회
+     * - 요청으로 들어온 reservationIds 중
+     *   해당 점장 가게에 속한 주문만 조회한다.
+     */
+    @EntityGraph(attributePaths = {
+            "member",
+            "store",
+            "store.storeManager",
+            "randomBox"
+    })
+    List<Reservation> findAllByIdInAndStore_Id(List<Long> reservationIds, Long storeId);
 }

--- a/src/main/java/Comprehensive_Design_Project/CUK_Compasser/domain/reservation/service/ReservationServiceImpl.java
+++ b/src/main/java/Comprehensive_Design_Project/CUK_Compasser/domain/reservation/service/ReservationServiceImpl.java
@@ -84,7 +84,6 @@ public class ReservationServiceImpl implements ReservationService {
     /**
      * 점장 예약 수락
      * - 선결제 후 수락 정책이므로 PAID 상태인 예약만 수락 가능하다.
-     * - 수락 시 재고 차감 + pickupStatus 를 PREPARING 으로 변경한다.
      */
     @Override
     @Transactional
@@ -151,6 +150,7 @@ public class ReservationServiceImpl implements ReservationService {
 
         // 이미 결제 완료된 예약을 점장이 거절하면 환불 처리
         if (reservation.getPaymentStatus() == PaymentStatus.PAID) {
+            validateRefundable(reservation);
             cancelKakaoPayPayment(reservation);
             reservation.markRefunded();
         }
@@ -374,4 +374,12 @@ public class ReservationServiceImpl implements ReservationService {
             throw new GeneralException(ErrorStatus.INVALID_PAYMENT_INFO);
         }
     }
+
+    private void validateRefundable(Reservation reservation) {
+        if (Boolean.TRUE.equals(reservation.getSettled())) {
+            throw new GeneralException(ErrorStatus.REFUND_NOT_ALLOWED_AFTER_SETTLEMENT);
+        }
+    }
+
+
 }

--- a/src/main/java/Comprehensive_Design_Project/CUK_Compasser/domain/reward/service/RewardService.java
+++ b/src/main/java/Comprehensive_Design_Project/CUK_Compasser/domain/reward/service/RewardService.java
@@ -55,7 +55,6 @@ public class RewardService {
         // reward -> select sum (r.stamp), sum (r.useCouponCnt) from Reward r where r.member.id = :memberId
         SummaryMemberReward rewardSummaryByMemberId = rewardRepository.findTotalRewardSummaryByMemberId(memberId);
 
-        // memberId -> select count(o) from Order o where o.member.id = :memberId And o.orderStatus = 'PICKED_UP'
         Long unboxingCnt = 1L;
 
         return rewardSummaryByMemberId.withUnboxedCount(unboxingCnt);

--- a/src/main/java/Comprehensive_Design_Project/CUK_Compasser/domain/settlement/controller/AdminSettlementController.java
+++ b/src/main/java/Comprehensive_Design_Project/CUK_Compasser/domain/settlement/controller/AdminSettlementController.java
@@ -1,0 +1,32 @@
+package Comprehensive_Design_Project.CUK_Compasser.domain.settlement.controller;
+
+import Comprehensive_Design_Project.CUK_Compasser.domain.settlement.dto.SettlementReqDTO;
+import Comprehensive_Design_Project.CUK_Compasser.domain.settlement.dto.SettlementRespDTO;
+import Comprehensive_Design_Project.CUK_Compasser.domain.settlement.service.SettlementService;
+import Comprehensive_Design_Project.CUK_Compasser.global.common.apiPayload.ApiResponse;
+import Comprehensive_Design_Project.CUK_Compasser.global.common.apiPayload.code.status.SuccessStatus;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import lombok.RequiredArgsConstructor;
+import org.springframework.web.bind.annotation.*;
+
+@RestController
+@RequiredArgsConstructor
+@RequestMapping("/admin/settlements")
+@Tag(name = "Admin Settlement", description = "운영자 정산 관리 API")
+public class AdminSettlementController {
+
+    private final SettlementService settlementService;
+
+    @Operation(summary = "정산 완료 처리", description = "운영자가 송금 완료 후 해당 가게 주문들을 정산 완료 처리합니다.")
+    @PostMapping("/{storeId}/complete")
+    public ApiResponse<SettlementRespDTO.SettlementCompleteDTO> completeSettlement(
+            @PathVariable Long storeId,
+            @RequestBody SettlementReqDTO.CompleteSettlementDTO request
+    ) {
+        return ApiResponse.onSuccess(
+                SuccessStatus.OK,
+                settlementService.completeSettlementByStore(storeId, request)
+        );
+    }
+}

--- a/src/main/java/Comprehensive_Design_Project/CUK_Compasser/domain/settlement/controller/SettlementController.java
+++ b/src/main/java/Comprehensive_Design_Project/CUK_Compasser/domain/settlement/controller/SettlementController.java
@@ -1,0 +1,33 @@
+package Comprehensive_Design_Project.CUK_Compasser.domain.settlement.controller;
+
+import Comprehensive_Design_Project.CUK_Compasser.domain.settlement.dto.SettlementReqDTO;
+import Comprehensive_Design_Project.CUK_Compasser.domain.settlement.dto.SettlementRespDTO;
+import Comprehensive_Design_Project.CUK_Compasser.domain.settlement.service.SettlementService;
+import Comprehensive_Design_Project.CUK_Compasser.global.common.apiPayload.ApiResponse;
+import Comprehensive_Design_Project.CUK_Compasser.global.common.apiPayload.code.status.SuccessStatus;
+import Comprehensive_Design_Project.CUK_Compasser.global.security.userDetails.CustomUserDetails;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import lombok.RequiredArgsConstructor;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.web.bind.annotation.*;
+
+@RestController
+@RequiredArgsConstructor
+@RequestMapping("/owners/my-store/settlements")
+@Tag(name = "Owner Settlement", description = "점장 정산 조회 API")
+public class SettlementController {
+
+    private final SettlementService settlementService;
+
+    @Operation(summary = "정산 대상 미리보기", description = "내 가게의 정산 가능한 주문 목록과 총 금액을 조회합니다.")
+    @GetMapping("/preview")
+    public ApiResponse<SettlementRespDTO.SettlementPreviewDTO> previewSettlement(
+            @AuthenticationPrincipal CustomUserDetails userDetails
+    ) {
+        return ApiResponse.onSuccess(
+                SuccessStatus.OK,
+                settlementService.previewSettlement(userDetails.getMember().getId())
+        );
+    }
+}

--- a/src/main/java/Comprehensive_Design_Project/CUK_Compasser/domain/settlement/converter/SettlementConverter.java
+++ b/src/main/java/Comprehensive_Design_Project/CUK_Compasser/domain/settlement/converter/SettlementConverter.java
@@ -1,0 +1,53 @@
+package Comprehensive_Design_Project.CUK_Compasser.domain.settlement.converter;
+
+import Comprehensive_Design_Project.CUK_Compasser.domain.reservation.entity.Reservation;
+import Comprehensive_Design_Project.CUK_Compasser.domain.settlement.dto.SettlementRespDTO;
+import Comprehensive_Design_Project.CUK_Compasser.domain.store.entity.Store;
+import org.springframework.stereotype.Component;
+
+import java.util.List;
+
+@Component
+public class SettlementConverter {
+
+    public SettlementRespDTO.SettlementPreviewDTO toSettlementPreviewDTO(Store store, List<Reservation> reservations) {
+        int totalAmount = reservations.stream()
+                .mapToInt(Reservation::getTotalPrice)
+                .sum();
+
+        List<SettlementRespDTO.SettlementReservationDTO> items = reservations.stream()
+                .map(this::toSettlementReservationDTO)
+                .toList();
+
+        return SettlementRespDTO.SettlementPreviewDTO.builder()
+                .storeId(store.getId())
+                .storeName(store.getStoreName())
+                .count(reservations.size())
+                .totalAmount(totalAmount)
+                .reservations(items)
+                .build();
+    }
+
+    public SettlementRespDTO.SettlementReservationDTO toSettlementReservationDTO(Reservation reservation) {
+        return SettlementRespDTO.SettlementReservationDTO.builder()
+                .reservationId(reservation.getId())
+                .memberId(reservation.getMember().getId())
+                .totalPrice(reservation.getTotalPrice())
+                .createdAt(reservation.getCreatedAt())
+                .build();
+    }
+
+    public SettlementRespDTO.SettlementCompleteDTO toSettlementCompleteDTO(Store store, List<Reservation> reservations) {
+        int totalAmount = reservations.stream()
+                .mapToInt(Reservation::getTotalPrice)
+                .sum();
+
+        return SettlementRespDTO.SettlementCompleteDTO.builder()
+                .storeId(store.getId())
+                .storeName(store.getStoreName())
+                .count(reservations.size())
+                .totalAmount(totalAmount)
+                .message("정산 완료 처리되었습니다.")
+                .build();
+    }
+}

--- a/src/main/java/Comprehensive_Design_Project/CUK_Compasser/domain/settlement/dto/SettlementReqDTO.java
+++ b/src/main/java/Comprehensive_Design_Project/CUK_Compasser/domain/settlement/dto/SettlementReqDTO.java
@@ -1,0 +1,15 @@
+package Comprehensive_Design_Project.CUK_Compasser.domain.settlement.dto;
+
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+import java.util.List;
+
+public class SettlementReqDTO {
+
+    @Getter
+    @NoArgsConstructor
+    public static class CompleteSettlementDTO {
+        private List<Long> reservationIds;
+    }
+}

--- a/src/main/java/Comprehensive_Design_Project/CUK_Compasser/domain/settlement/dto/SettlementRespDTO.java
+++ b/src/main/java/Comprehensive_Design_Project/CUK_Compasser/domain/settlement/dto/SettlementRespDTO.java
@@ -1,0 +1,44 @@
+package Comprehensive_Design_Project.CUK_Compasser.domain.settlement.dto;
+
+import lombok.*;
+
+import java.time.LocalDateTime;
+import java.util.List;
+
+public class SettlementRespDTO {
+
+    @Getter
+    @Builder
+    @NoArgsConstructor
+    @AllArgsConstructor
+    public static class SettlementPreviewDTO {
+        private Long storeId;
+        private String storeName;
+        private Integer count;
+        private Integer totalAmount;
+        private List<SettlementReservationDTO> reservations;
+    }
+
+    @Getter
+    @Builder
+    @NoArgsConstructor
+    @AllArgsConstructor
+    public static class SettlementReservationDTO {
+        private Long reservationId;
+        private Long memberId;
+        private Integer totalPrice;
+        private LocalDateTime createdAt;
+    }
+
+    @Getter
+    @Builder
+    @NoArgsConstructor
+    @AllArgsConstructor
+    public static class SettlementCompleteDTO {
+        private Long storeId;
+        private String storeName;
+        private Integer count;
+        private Integer totalAmount;
+        private String message;
+    }
+}

--- a/src/main/java/Comprehensive_Design_Project/CUK_Compasser/domain/settlement/service/SettlementService.java
+++ b/src/main/java/Comprehensive_Design_Project/CUK_Compasser/domain/settlement/service/SettlementService.java
@@ -1,0 +1,10 @@
+package Comprehensive_Design_Project.CUK_Compasser.domain.settlement.service;
+
+import Comprehensive_Design_Project.CUK_Compasser.domain.settlement.dto.SettlementReqDTO;
+import Comprehensive_Design_Project.CUK_Compasser.domain.settlement.dto.SettlementRespDTO;
+
+public interface SettlementService {
+    SettlementRespDTO.SettlementPreviewDTO previewSettlement(Long ownerId);
+
+    SettlementRespDTO.SettlementCompleteDTO completeSettlementByStore(Long ownerId, SettlementReqDTO.CompleteSettlementDTO request);
+}

--- a/src/main/java/Comprehensive_Design_Project/CUK_Compasser/domain/settlement/service/SettlementServiceImpl.java
+++ b/src/main/java/Comprehensive_Design_Project/CUK_Compasser/domain/settlement/service/SettlementServiceImpl.java
@@ -1,0 +1,83 @@
+package Comprehensive_Design_Project.CUK_Compasser.domain.settlement.service;
+
+import Comprehensive_Design_Project.CUK_Compasser.domain.reservation.entity.PaymentStatus;
+import Comprehensive_Design_Project.CUK_Compasser.domain.reservation.entity.Reservation;
+import Comprehensive_Design_Project.CUK_Compasser.domain.reservation.entity.ReservationStatus;
+import Comprehensive_Design_Project.CUK_Compasser.domain.reservation.repository.ReservationRepository;
+import Comprehensive_Design_Project.CUK_Compasser.domain.settlement.converter.SettlementConverter;
+import Comprehensive_Design_Project.CUK_Compasser.domain.settlement.dto.SettlementReqDTO;
+import Comprehensive_Design_Project.CUK_Compasser.domain.settlement.dto.SettlementRespDTO;
+import Comprehensive_Design_Project.CUK_Compasser.domain.store.entity.Store;
+import Comprehensive_Design_Project.CUK_Compasser.domain.store.repository.StoreRepository;
+import Comprehensive_Design_Project.CUK_Compasser.global.common.apiPayload.code.status.ErrorStatus;
+import Comprehensive_Design_Project.CUK_Compasser.global.common.apiPayload.exception.GeneralException;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.util.List;
+
+@Service
+@RequiredArgsConstructor
+@Transactional(readOnly = true)
+public class SettlementServiceImpl implements SettlementService {
+
+    private final StoreRepository storeRepository;
+    private final ReservationRepository reservationRepository;
+    private final SettlementConverter settlementConverter;
+
+    @Override
+    public SettlementRespDTO.SettlementPreviewDTO previewSettlement(Long ownerId) {
+        Store store = storeRepository.findByStoreManager_MemberId(ownerId)
+                .orElseThrow(() -> new GeneralException(ErrorStatus.STORE_NOT_FOUND));
+
+        List<Reservation> targets =
+                reservationRepository.findAllByStore_IdAndStatusAndPaymentStatusAndSettledFalseOrderByCreatedAtAsc(
+                        store.getId(),
+                        ReservationStatus.APPROVED,
+                        PaymentStatus.PAID
+                );
+
+        return settlementConverter.toSettlementPreviewDTO(store, targets);
+    }
+
+    @Override
+    @Transactional
+    public SettlementRespDTO.SettlementCompleteDTO completeSettlementByStore(Long ownerId, SettlementReqDTO.CompleteSettlementDTO request) {
+        if (request.getReservationIds() == null || request.getReservationIds().isEmpty()) {
+            throw new GeneralException(ErrorStatus.INVALID_SETTLEMENT_REQUEST);
+        }
+
+        Store store = storeRepository.findByStoreManager_MemberId(ownerId)
+                .orElseThrow(() -> new GeneralException(ErrorStatus.STORE_NOT_FOUND));
+
+        List<Reservation> reservations =
+                reservationRepository.findAllByIdInAndStore_Id(request.getReservationIds(), store.getId());
+
+        if (reservations.isEmpty()) {
+            throw new GeneralException(ErrorStatus.SETTLEMENT_TARGET_NOT_FOUND);
+        }
+
+        for (Reservation reservation : reservations) {
+            validateSettlementTarget(reservation);
+        }
+
+        reservations.forEach(Reservation::markSettled);
+
+        return settlementConverter.toSettlementCompleteDTO(store, reservations);
+    }
+
+    private void validateSettlementTarget(Reservation reservation) {
+        if (reservation.getStatus() != ReservationStatus.APPROVED) {
+            throw new GeneralException(ErrorStatus.INVALID_RESERVATION_STATUS);
+        }
+
+        if (reservation.getPaymentStatus() != PaymentStatus.PAID) {
+            throw new GeneralException(ErrorStatus.INVALID_PAYMENT_STATUS);
+        }
+
+        if (Boolean.TRUE.equals(reservation.getSettled())) {
+            throw new GeneralException(ErrorStatus.ALREADY_SETTLED);
+        }
+    }
+}

--- a/src/main/java/Comprehensive_Design_Project/CUK_Compasser/global/common/apiPayload/code/status/ErrorStatus.java
+++ b/src/main/java/Comprehensive_Design_Project/CUK_Compasser/global/common/apiPayload/code/status/ErrorStatus.java
@@ -100,7 +100,6 @@ public enum ErrorStatus implements BaseErrorCode {
     INVALID_RESERVATION_STATUS(HttpStatus.BAD_REQUEST, "R005", "변경할 수 없는 예약 상태입니다."),
     RESERVATION_ALREADY_APPROVED(HttpStatus.BAD_REQUEST, "R006", "이미 승인된 예약입니다."),
     RESERVATION_ALREADY_REJECTED(HttpStatus.BAD_REQUEST, "R007", "이미 거절된 예약입니다."),
-    RESERVATION_ALREADY_PICKED_UP(HttpStatus.BAD_REQUEST, "R008", "이미 픽업된 예약입니다."),
     RESERVATION_ALREADY_PAID(HttpStatus.CONFLICT, "R010", "이미 결제가 완료된 예약입니다."),
 
 
@@ -121,7 +120,15 @@ public enum ErrorStatus implements BaseErrorCode {
     INVALID_PAYMENT_STATUS(HttpStatus.BAD_REQUEST, "P005", "현재 결제 상태에서는 요청할 수 없습니다."),
     INVALID_PAYMENT_AMOUNT(HttpStatus.BAD_REQUEST, "P006", "결제 금액이 주문 금액과 일치하지 않습니다."),
     INVALID_PAYMENT_INFO(HttpStatus.BAD_REQUEST, "P007", "결제 승인 정보가 올바르지 않습니다."),
-    KAKAOPAY_CANCEL_FAILED(HttpStatus.BAD_REQUEST, "P008", "카카오페이 결제 취소에 실패했습니다.");
+    KAKAOPAY_CANCEL_FAILED(HttpStatus.BAD_REQUEST, "P008", "카카오페이 결제 취소에 실패했습니다."),
+
+    // =========================
+    // [Settlement]
+    // =========================
+    ALREADY_SETTLED(HttpStatus.BAD_REQUEST, "S001", "이미 정산 완료된 주문입니다."),
+    REFUND_NOT_ALLOWED_AFTER_SETTLEMENT(HttpStatus.BAD_REQUEST, "S002", "정산 완료된 주문은 환불할 수 없습니다."),
+    SETTLEMENT_TARGET_NOT_FOUND(HttpStatus.NOT_FOUND, "S003", "정산 대상 주문이 없습니다."),
+    INVALID_SETTLEMENT_REQUEST(HttpStatus.BAD_REQUEST, "S004", "정산 요청이 올바르지 않습니다.");
 
     private final HttpStatus httpStatus;
     private final String code;


### PR DESCRIPTION
## ❗Pull Request!

### 연관 이슈
<!--관련있는 이슈 번호(#000)을 적어주세요. 해당 pull request merge와 함께 이슈를 닫으려면 closed #Issue_number를 적어주세요 -->
- #62 
- #63 
- #61 

### 📝 작업 상세 내용
<!-- 이미지를 첨부해도 괜찮으니 어떤 작업을 했는지 요약해 주세요. 주요 변경 코드나 구조 설명이 필요하면 작성해주세요. -->
- 카카오페이 선결제 흐름 기준으로 주문/예약 상태 전이를 정리했습니다.
- 카카오페이 결제 준비(`ready`), 승인(`approve`), 결제창 취소(`cancel`) 흐름을 연결하고 승인 응답 검증 로직을 보완했습니다.
- 결제 승인 실패 시 `paymentStatus = FAILED` 처리 후 같은 reservation으로 재결제가 가능하도록 로직을 정리했습니다.
- 사용자 주문 취소 및 점장 예약 거절 시 카카오페이 환불 로직을 반영하고, 환불 완료 시 `paymentStatus = REFUNDED` 상태를 사용하도록 수정했습니다.
- 점장 예약 수락은 `paymentStatus = PAID` 인 경우에만 가능하도록 검증을 추가했습니다.
- 수동 정산 구조 도입을 위해 `Reservation`에 정산 여부를 관리하는 `settled`, `settledAt` 필드를 추가했습니다.
- 정산 대상 조회 및 정산 완료 처리를 위한 settlement 관련 DTO, converter, service, controller 구조를 추가했습니다.
- 정산 대상은 `APPROVED + PAID + settled = false` 기준으로 조회하도록 repository 메서드를 추가했습니다.
- 정산 완료된 주문은 환불할 수 없도록 검증 로직을 추가했습니다.
- 카카오페이 콜백 처리와 설정값 주입 과정에서 필요한 properties 구조를 정리했습니다.

### ✅ 체크리스트
- [ ] 테스트를 거쳤나요?


### 🙋🏻‍♀️ 리뷰 요구사항 (optional)
<!-- 무조건 리뷰되어야 하는 부분이 있음 작성해주세요! -->

- `APPROVED` 상태를 정산 기준으로 바로 사용하는 정책이 적절한지 검토 부탁드립니다.
- 정산 완료 이후 환불 불가 정책이 현재 서비스 정책과 맞는지 확인 부탁드립니다.
- 카카오페이 공용 CID 기반 구조로 갈지, 추후 점장별 정산 확장 가능성을 고려해야 할지 의견 부탁드립니다.