### PR TITLE
fix - 카카오 로그인 시 리다이렉트 기능 추가

### DIFF
--- a/src/main/java/Comprehensive_Design_Project/CUK_Compasser/domain/oAuth2/controller/OAuth2Controller.java
+++ b/src/main/java/Comprehensive_Design_Project/CUK_Compasser/domain/oAuth2/controller/OAuth2Controller.java
@@ -7,8 +7,11 @@ import Comprehensive_Design_Project.CUK_Compasser.domain.oAuth2.dto.SignUpReqDTO
 import Comprehensive_Design_Project.CUK_Compasser.domain.oAuth2.dto.SignUpRespDTO;
 import Comprehensive_Design_Project.CUK_Compasser.domain.oAuth2.dto.TokenRespDTO;
 import Comprehensive_Design_Project.CUK_Compasser.global.common.apiPayload.ApiResponse;
+import Comprehensive_Design_Project.CUK_Compasser.global.common.apiPayload.code.generalStatus.GeneralErrorCode;
+import Comprehensive_Design_Project.CUK_Compasser.global.common.apiPayload.code.status.ErrorStatus;
 import Comprehensive_Design_Project.CUK_Compasser.global.common.apiPayload.code.status.SuccessStatus;
 import Comprehensive_Design_Project.CUK_Compasser.domain.oAuth2.service.OAuth2Service;
+import Comprehensive_Design_Project.CUK_Compasser.global.common.apiPayload.exception.GeneralException;
 import Comprehensive_Design_Project.CUK_Compasser.global.security.userDetails.CustomUserDetails;
 import io.swagger.v3.oas.annotations.Operation;
 import jakarta.servlet.http.HttpServletRequest;
@@ -21,6 +24,8 @@ import org.springframework.http.HttpHeaders;
 import org.springframework.http.ResponseCookie;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.web.bind.annotation.*;
+
+import java.io.IOException;
 
 @Slf4j
 @RequiredArgsConstructor
@@ -74,7 +79,8 @@ public class OAuth2Controller {
     }
 
     @GetMapping("/code/kakao") // 카카오 회원가입 or 로그인 서비스 == GET 요청
-    @Operation(summary = "카카오 로그인 API", description = "사용자가 카카오 로그인 동의 후 받는 API 입니다. 카카오 서버에서 바로 BE 서버로 리다이렉트 해줘서 딱히 접근할 일이 없어요.")
+    @Operation(summary = "카카오 로그인 API", description = "사용자가 카카오 로그인 동의 후 받는 API 입니다. 카카오 서버 인증 후 받은 memberName과 함께 " +
+            "https://compasser.co.kr/auth/callback?accessToken={accessToken} 로 리다이렉트 하는 API 입니다.")
     public ApiResponse<Object> callback (@RequestParam("code") String code, HttpServletResponse response) {
 
         MemberRespDTO.MemberInfoDTO memberInfo = oAuth2Service.loginWithKakao(code);
@@ -87,6 +93,12 @@ public class OAuth2Controller {
                 .sameSite("Strict")
                 .build();
         response.setHeader(HttpHeaders.SET_COOKIE, cookie.toString());
+
+        try {
+            response.sendRedirect("https://compasser.co.kr/auth/callback?accessToken=".concat(memberInfo.getJwt().getAccessToken()) );
+        } catch (IOException e) {
+            throw new GeneralException(GeneralErrorCode.WRONG_REDIRECT_URL);
+        }
 
         MemberRespDTO.LoginRespDTO respDTO = MemberRespDTO.LoginRespDTO.builder().isSuccess(true).memberName(memberInfo.getMemberName()).accessToken(memberInfo.getJwt().getAccessToken()).build();
         return ApiResponse.onSuccess(SuccessStatus.OK, respDTO);

--- a/src/main/java/Comprehensive_Design_Project/CUK_Compasser/global/common/apiPayload/code/generalStatus/GeneralErrorCode.java
+++ b/src/main/java/Comprehensive_Design_Project/CUK_Compasser/global/common/apiPayload/code/generalStatus/GeneralErrorCode.java
@@ -21,7 +21,8 @@ public enum GeneralErrorCode implements BaseErrorCode {
     MEMBER_NOT_FOUND(HttpStatus.NOT_FOUND, "G007", "토큰을 통해 사용자를 찾을 수 없습니다.."),
     BLACKLIST_TOKEN(HttpStatus.UNAUTHORIZED, "G008", "블랙리스트에 등록된 토큰입니다."),
     RT_NOT_FOUND(HttpStatus.UNAUTHORIZED, "G008", "리프레쉬 토큰을 찾을 수 없습니다."),
-    VALIDATION_ERROR(HttpStatus.BAD_REQUEST, "G007", "입력값 검증에 실패했습니다.");
+    VALIDATION_ERROR(HttpStatus.BAD_REQUEST, "G007", "입력값 검증에 실패했습니다."),
+    WRONG_REDIRECT_URL(HttpStatus.BAD_REQUEST, "G009", "리다이렉트에 실패했습니다.");
 
     private final HttpStatus httpStatus;  // ex: 200 OK
     private final String code;


### PR DESCRIPTION


## ❗Pull Request!

### 연관 이슈
<!--관련있는 이슈 번호(#000)을 적어주세요. 해당 pull request merge와 함께 이슈를 닫으려면 closed #Issue_number를 적어주세요 -->
- #13 


### 📝 작업 상세 내용
<!-- 이미지를 첨부해도 괜찮으니 어떤 작업을 했는지 요약해 주세요. 주요 변경 코드나 구조 설명이 필요하면 작성해주세요. -->
- 카카오 로그인 성공 시 JSON 데이터를 그대로 반환해서 브라우저에 팝업되는 문제 발생
- 서버 내 리다이렉트를 통해 반환 
- 스웨거 설명 수정

### ✅ 체크리스트
- [x] 테스트를 거쳤나요?


### 🙋🏻‍♀️ 리뷰 요구사항 (optional)
<!-- 무조건 리뷰되어야 하는 부분이 있음 작성해주세요! -->
-